### PR TITLE
Fix conflict with Markdown On Save plugin

### DIFF
--- a/jekyll-export.php
+++ b/jekyll-export.php
@@ -188,7 +188,7 @@ class Jekyll_Export {
 		if ( !class_exists( 'spyc' ) )
 			require_once dirname( __FILE__ ) . '/includes/spyc.php';
 
-		if ( !function_exists( 'Markdown' ) )
+		if ( !class_exists( 'Markdownify_Extra' ) )
 			require_once dirname( __FILE__ ) . '/includes/markdownify/markdownify_extra.php';
 			
 		$this->dir = sys_get_temp_dir() . '/wp-jekyll-' . md5( time() ) . '/';


### PR DESCRIPTION
If you also have @markjaquith's [markdown-on-save](https://github.com/markjaquith/markdown-on-save) plugin activated, you'll get a fatal error when trying to run Export to Jekyll.

Not sure why it checks for a `Markdown` function, since it doesn't exist anywhere in the markdownify library.
