### PR TITLE
remind users about zip.so

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,9 @@ Usage
 -----
 
 1. Place plugin in `/wp-content/plugins/` folder
-2. Activate plugin in WordPress dashboard
-3. Select `Export to Jekyll` from the `Tools` menu
+2. Make sure `extension=zip.so` line is uncommented in your `php.ini`
+3. Activate plugin in WordPress dashboard
+4. Select `Export to Jekyll` from the `Tools` menu
 
 Changelog
 ---------


### PR DESCRIPTION
Without it I keep getting the following error message...

```
[05-Mar-2013 23:21:26] WARNING: [pool www] child 32584 said into stderr: "NOTICE: PHP message: PHP Fatal error:  Class 'ZipArchive' not found in /srv/http/jiehan.org/blog/public_html/wp-content/plugins/wordpress-to-jekyll-exporter/jekyll-export.php on line 328"
```
