### PR TITLE
Fix for subdirectory installs (Issue #32)

### DIFF
--- a/jekyll-export.php
+++ b/jekyll-export.php
@@ -412,7 +412,7 @@ class Jekyll_Export {
   function convert_uploads() {
 
     $upload_dir = wp_upload_dir();
-    $this->copy_recursive( $upload_dir['basedir'], $this->dir . str_replace( trailingslashit( get_home_url() ), '', $upload_dir['baseurl'] )  );
+    $this->copy_recursive( $upload_dir['basedir'], $this->dir . str_replace( trailingslashit( get_site_url() ), '', $upload_dir['baseurl'] )  );
 
   }
 


### PR DESCRIPTION
Make convert_uploads work properly when wp-content is in a subdirectory, when site_url != home_url.
