### PR TITLE
Add a post's ID to the extracted metadata

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -96,6 +96,7 @@ class Jekyll_Export {
   function convert_meta( $post ) {
 
     $output = array(
+      'id'      => $post->ID,
       'title'   => get_the_title( $post ),
       'author'  => get_userdata( $post->post_author )->display_name,
       'excerpt' => $post->post_excerpt,

--- a/tests/test-wordpress-to-jekyll-exporter.php
+++ b/tests/test-wordpress-to-jekyll-exporter.php
@@ -68,6 +68,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
     $post = get_post($posts[1]);
     $meta = $jekyll_export->convert_meta($post);
     $expected = Array (
+      'id'        => $post->ID,
       'title'     => 'Test Post',
       'author'    => 'Tester',
       'excerpt'   => '',


### PR DESCRIPTION
I'm sure this will be useful for more than what I'm using it, but I need this in the metadata so I can reconstruct the Disqus identifiers correctly.

In my case, the identifiers look like `168 http://www.opensourcery.co.za/?p=168`, but the permalinks that are exported look like `/2009/03/20/pluck-out-an-old-revision-of-a-file-with-git-show/`, so I had no other way of even inferring the id.
