### PR TITLE
Add the post's guid to the extracted frontmatter

### DIFF
--- a/jekyll-exporter.php
+++ b/jekyll-exporter.php
@@ -101,6 +101,7 @@ class Jekyll_Export {
       'author'  => get_userdata( $post->post_author )->display_name,
       'excerpt' => $post->post_excerpt,
       'layout'  => get_post_type( $post ),
+      'guid'    => $post->guid
     );
 
     //preserve exact permalink, since Jekyll doesn't support redirection

--- a/tests/test-wordpress-to-jekyll-exporter.php
+++ b/tests/test-wordpress-to-jekyll-exporter.php
@@ -74,6 +74,7 @@ class WordPressToJekyllExporterTest extends WP_UnitTestCase {
       'excerpt'   => '',
       'layout'    => 'post',
       'permalink' => '/?p=9',
+      'guid'      => $post->guid
     );
     $this->assertEquals($expected, $meta);
   }


### PR DESCRIPTION
Extension of #43, seems the post's GUID's are also instrumental for recreating Disqus identifiers. I suspect GUID's might be useful in other cases too, like where Wordpress used it for feeds.
